### PR TITLE
Change the default width to 70 characters

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -42,7 +42,7 @@ func New(size int64) *Bar {
 			Renderer: &TTYRenderer{
 				Out:            os.Stderr,
 				ProgressMarker: ".",
-				terminalWidth:  80,
+				terminalWidth:  70,
 			},
 			Size: size,
 		}
@@ -51,7 +51,7 @@ func New(size int64) *Bar {
 			Renderer: &NoTTYRenderer{
 				Out:            os.Stderr,
 				ProgressMarker: ".",
-				terminalWidth:  80,
+				terminalWidth:  70,
 			},
 			Size: size,
 		}


### PR DESCRIPTION
```
The default 80 width is a little too wide, and will lead to hundres of lines
being printed when the terminal is not wide enough (like a regular 80 width
terminal, which in fact only has room for 78 characters). This gives it a little
bit of room for error.
```

I want this in before the codefreeze, so that we don't ship the original setup. Original plan was to have it detect the term size automatically, but I don't think I'll be able to find the time for it before we release.