### PR TITLE
MEN-8127: Fix "overflow" on the reported percentage

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -60,6 +60,10 @@ func New(size int64) *Bar {
 
 func (b *Bar) Tick(n int64) {
 	b.currentCount += n
+	// The last tick may be bigger than the remaining size
+	if b.currentCount > b.Size {
+		b.currentCount = b.Size
+	}
 	if b.Size > 0 {
 		percentage := int((float64(b.currentCount) / float64(b.Size)) * 100)
 		b.Percentage = percentage
@@ -91,10 +95,6 @@ func (p *TTYRenderer) Render(percentage int) {
 	widthAvailable := p.terminalWidth - len(suffix)
 	number_of_dots := int((float64(widthAvailable) * float64(percentage)) / 100)
 	number_of_fillers := widthAvailable - number_of_dots
-	if percentage > 100 {
-		number_of_dots = widthAvailable
-		number_of_fillers = 0
-	}
 	if percentage < 0 {
 		return
 	}

--- a/progress_test.go
+++ b/progress_test.go
@@ -17,8 +17,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"strings"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProgressTTY(t *testing.T) {
@@ -59,7 +60,28 @@ func TestProgressTTY(t *testing.T) {
 	b.Reset()
 	p.Tick(10)
 	assert.Equal(t,
-		"\r........................................................................ - 110 %",
+		"",
+		b.String())
+}
+
+func TestProgressTTYOverTick(t *testing.T) {
+	b := &bytes.Buffer{}
+	p := &Bar{
+		Renderer: &TTYRenderer{
+			Out:            b,
+			ProgressMarker: ".",
+			terminalWidth:  80,
+		},
+		Size: 100,
+	}
+	p.Tick(80)
+	assert.Equal(t,
+		"\r.........................................................                -  80 %",
+		b.String())
+	b.Reset()
+	p.Tick(30)
+	assert.Equal(t,
+		"\r........................................................................ - 100 %\n",
 		b.String())
 }
 


### PR DESCRIPTION
The last tick will be of the block size being read, which may be bigger than the remaining size.

On big files this is not appreciable, but for example if you are writing a file of less than the block size the progress will end with >100%.